### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
         echo "::set-output name=RELEASE_CHANGELOG::$(Escape-NewLines "$CHANGELOG")"
 
     - name: Publish GitHub Release
-      uses: svenstaro/upload-release-action@2.3.0
+      uses: svenstaro/upload-release-action@2.4.0
       with:
         asset_name: "${{ inputs.INSTALLER_NAME }}.${{inputs.ARCHIVE_TYPE}}"
         file: "${{ github.workspace }}/${{ inputs.INSTALLER_NAME }}.${{inputs.ARCHIVE_TYPE}}"


### PR DESCRIPTION
Updates `upload-release-action` to fix CI error when publishing github releases.