### PR TITLE
feat: read vcpkg commit id from vcpkg.json file instead

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -37,9 +37,6 @@ on:
       VARIANT:
         type: string
         required: true
-      VCPKG_COMMIT_ID:
-        type: string
-        required: true
     secrets:
       GIT_SSH_KEY:
         required: false
@@ -90,7 +87,6 @@ jobs:
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: '${{ inputs.VCPKG_COMMIT_ID }}'
         vcpkgJsonGlob: './${{inputs.CMAKE_PROJECT_DIR}}/vcpkg.json'
 
     - name: Configure CMake

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -76,11 +76,6 @@ on:
         type: string
         required: false
         default: "buildvr"
-      VCPKG_COMMIT_ID:
-        type: string
-        description: "Commit SHA of the vcpkg repository to use when building a project."
-        required: false
-        default: '06475a351672e6fad52e707b33e30eaf2811d341'
       AE_353_BRANCH:
         type: string
         description: "Name of the branch in current repository that is compatible with 1.6.353 version. By default 353 build is disabled. In order to enable it this input must be set. If 353 is build from main branch you can specify it here."
@@ -337,7 +332,6 @@ jobs:
       CMAKE_CONFIG_PRESET: ${{ inputs.CMAKE_SE_CONFIG_PRESET }}
       CMAKE_BUILD_PRESET: ${{ inputs.CMAKE_SE_BUILD_PRESET }}
       CMAKE_CONFIG: ${{ inputs.CMAKE_BUILD_CONFIGURATION }}
-      VCPKG_COMMIT_ID: ${{ inputs.VCPKG_COMMIT_ID }}
       BINARY_DIR: ${{ inputs.CMAKE_SE_BINARY_DIR }}
       BINARY_NAME: ${{ inputs.CMAKE_BINARY_NAME }}
       BINARY_NAME_VAR: ${{ inputs.CMAKE_BINARY_NAME_VAR }}
@@ -356,7 +350,6 @@ jobs:
       CMAKE_CONFIG_PRESET: ${{ inputs.CMAKE_AE_CONFIG_PRESET }}
       CMAKE_BUILD_PRESET: ${{ inputs.CMAKE_AE_BUILD_PRESET }}
       CMAKE_CONFIG: ${{ inputs.CMAKE_BUILD_CONFIGURATION }}
-      VCPKG_COMMIT_ID: ${{ inputs.VCPKG_COMMIT_ID }}
       BINARY_DIR: ${{ inputs.CMAKE_AE_BINARY_DIR }}
       BINARY_NAME: ${{ inputs.CMAKE_BINARY_NAME }}
       BINARY_NAME_VAR: ${{ inputs.CMAKE_BINARY_NAME_VAR }}
@@ -377,7 +370,6 @@ jobs:
       CMAKE_CONFIG_PRESET: ${{ inputs.CMAKE_AE_CONFIG_PRESET }}
       CMAKE_BUILD_PRESET: ${{ inputs.CMAKE_AE_BUILD_PRESET }}
       CMAKE_CONFIG: ${{ inputs.CMAKE_BUILD_CONFIGURATION }}
-      VCPKG_COMMIT_ID: ${{ inputs.VCPKG_COMMIT_ID }}
       BINARY_DIR: ${{ inputs.CMAKE_AE_BINARY_DIR }}
       BINARY_NAME: ${{ inputs.CMAKE_BINARY_NAME }}
       BINARY_NAME_VAR: ${{ inputs.CMAKE_BINARY_NAME_VAR }}
@@ -396,7 +388,6 @@ jobs:
       CMAKE_CONFIG_PRESET: ${{ inputs.CMAKE_VR_CONFIG_PRESET }}
       CMAKE_BUILD_PRESET: ${{ inputs.CMAKE_VR_BUILD_PRESET }}
       CMAKE_CONFIG: ${{ inputs.CMAKE_BUILD_CONFIGURATION }}
-      VCPKG_COMMIT_ID: ${{ inputs.VCPKG_COMMIT_ID }}
       BINARY_DIR: ${{ inputs.CMAKE_VR_BINARY_DIR }}
       BINARY_NAME: ${{ inputs.CMAKE_BINARY_NAME }}
       BINARY_NAME_VAR: ${{ inputs.CMAKE_BINARY_NAME_VAR }}


### PR DESCRIPTION
if `vcpkgGitCommitId` is not specified when using lukka/run-vcpkg it will instead read the `builtin-baseline` from vcpkg.json if using the `vcpkgJsonGlob` parameter.

So this PR removes the need to update the workflow file everytime the baseline is bumped in vcpkg, aka removing the need to update it in 2 places every time.

The `builtin-baseline` is always set on po3's mods, so this will work with all existing projects